### PR TITLE
Correct the compilation example

### DIFF
--- a/docs/HowTo/compile.md
+++ b/docs/HowTo/compile.md
@@ -12,7 +12,7 @@ The `frontend.Compile` method takes a high-level program and translates it to a 
 
 ```go
 var myCircuit Circuit
-r1cs, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &myCircuit)
+r1cs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &myCircuit)
 ```
 
 :::tip Playground


### PR DESCRIPTION
The `BN254` can not be used directly anymore and its `ScalarField()` method should be called.

For content changes:

- [x] Documentation content
- [x] Documentation page organization
